### PR TITLE
Update webr

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.302",
       "license": "MIT",
       "dependencies": {
-        "webr": "^0.5.8",
+        "webr": "^0.5.9",
         "ws": "^8.20.0"
       },
       "bin": {
@@ -1250,9 +1250,9 @@
       "license": "MIT"
     },
     "node_modules/webr": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/webr/-/webr-0.5.8.tgz",
-      "integrity": "sha512-UoDO0MmBe5j+8f4vUHNVbEgMcCYNEQM44gfK9dpJwLxIj4VpmaHesy/Cy2JSo5HRxC9tMYkqcu5US5qlJOEtNw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/webr/-/webr-0.5.9.tgz",
+      "integrity": "sha512-Hzg6AK7+GiegMz+nrHZQLWA3q3F5Ku6WNkuUPqQN2yJXYFtRXdikMebfXUXu5MAixvoeXzWXu+bZQhJgxuz1Jg==",
       "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
         "@codemirror/autocomplete": "^6.8.1",

--- a/js/package.json
+++ b/js/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "webr": "^0.5.8",
+    "webr": "^0.5.9",
     "ws": "^8.20.0"
   },
   "main": "index.js",


### PR DESCRIPTION
@HenrikBengtsson I think this should fix the curl support on node/deno using the [ws-proxy](https://github.com/r-wasm/ws-proxy#minimal-example-with-a-public-proxy-server).